### PR TITLE
Fix fread reporting EOF early in some cases on Windows.

### DIFF
--- a/clcc/clcc.c
+++ b/clcc/clcc.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
         options = "";
     }
 
-    sourceFile = fopen(sourceFilename, "r");
+    sourceFile = fopen(sourceFilename, "r+b");
     if (sourceFile == NULL)
     {
         perror(sourceFilename);
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
     assert(binary != NULL);
 
 
-    binaryFile = fopen(binaryFilename, "w");
+    binaryFile = fopen(binaryFilename, "w+b");
     if (binaryFile == NULL)
     {
         perror(binaryFilename);


### PR DESCRIPTION
Had some trouble reading in kernel source code when executing the tool on Windows.

Reading it in as a binary file fixes the issues. I also changed the output stream to a binary stream since there is no reason why Windows should do any conversions (e.g. LF -> CRLF...) and we want to have the unmodified file from the Nvidia compiler.

Btw: I used the nvcompiler.dll from the 381.65 driver release and the necessary symbols are still exported.