### PR TITLE
Handle read-only input files. (Wrong flags in previous commit)

### DIFF
--- a/clcc/clcc.c
+++ b/clcc/clcc.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
         options = "";
     }
 
-    sourceFile = fopen(sourceFilename, "r+b");
+    sourceFile = fopen(sourceFilename, "rb");
     if (sourceFile == NULL)
     {
         perror(sourceFilename);


### PR DESCRIPTION
Sorry! There was a mistake in my previous commit.
"r+b" opens a file with read and update permissions which causes problems with read-only files. (Which you would have if you for example work with Perforce or TFS(?).)

"rb" is the corect set of flags.

Thanks!